### PR TITLE
Update for ndarray 0.4.2 and ndarray-rblas 0.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,5 @@ num = "0.1.30"
 quick-error = "0.2.1"
 rand = "0.3.12"
 rblas = "0.0.13"
-
-[dependencies.ndarray]
-features = ["rblas"]
-version = "0.3.0"
+ndarray = "0.4.2"
+ndarray-rblas = "0.1.0"

--- a/src/bin/image-columns-nmf.rs
+++ b/src/bin/image-columns-nmf.rs
@@ -16,8 +16,9 @@ use rblas::{Gemm, Matrix};
 use rblas::attribute::Transpose;
 
 extern crate ndarray;
+extern crate ndarray_rblas;
 use ndarray::{Si, S};
-use ndarray::blas::{BlasArrayViewMut, AsBlas};
+use ndarray_rblas::{BlasArrayViewMut, AsBlas};
 
 extern crate nalgebra;
 use nalgebra::{DMat};

--- a/src/bin/rblas_ndarray_generic_compilation_test.rs
+++ b/src/bin/rblas_ndarray_generic_compilation_test.rs
@@ -8,9 +8,10 @@ use rblas::{Gemm};
 use rblas::matrix::Matrix;
 
 extern crate ndarray;
+extern crate ndarray_rblas;
 // this implements Matrix for BlasArrayViewMut
-use ndarray::blas::{AsBlas, BlasArrayViewMut};
-use ndarray::blas;
+use ndarray_rblas::{AsBlas, BlasArrayViewMut};
+use ndarray_rblas as blas;
 use ndarray::{ArrayBase, DataOwned, DataMut};
 
 fn multiply_f64(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ extern crate rand;
 extern crate image;
 extern crate ndarray;
 extern crate rblas;
+extern crate ndarray_rblas;
 
 pub mod testimage_generator;
 

--- a/src/nmf_blas.rs
+++ b/src/nmf_blas.rs
@@ -7,7 +7,7 @@ use rblas::{Gemm, Matrix};
 use rblas::attribute::Transpose;
 
 use ndarray::{ArrayBase, DataOwned, DataMut};
-use ndarray::blas::{BlasArrayViewMut, AsBlas};
+use ndarray_rblas::{BlasArrayViewMut, AsBlas};
 
 use helpers::{random01, Dims, Array2D};
 


### PR DESCRIPTION
Hi! ndarray's rblas bindings moved to a separate crate. I found your project via github's code search and I thought I might as well check that your code continues to compile with the crate split, and it does.

Right now it doesn't look like ndarray will continue down the rblas path for its core blas integration. rblas is still much more versatile than what play ndarray has (just matrix multiply and dot product uses BLAS).
